### PR TITLE
Add navigation bar with search and employee details

### DIFF
--- a/usermanagement/urls.py
+++ b/usermanagement/urls.py
@@ -8,7 +8,9 @@ from django.urls import path
 from users.views import (
     comparison_view,
     crowd_users_view,
+    employee_detail_view,
     external_employees_view,
+    search_employees,
 )
 
 urlpatterns = [
@@ -16,4 +18,6 @@ urlpatterns = [
     path("compare/", comparison_view, name="compare"),
     path("employees/", external_employees_view, name="employees"),
     path("crowd_users/", crowd_users_view, name="crowd_users"),
+    path("employee/<str:employee_id>/", employee_detail_view, name="employee_detail"),
+    path("search/", search_employees, name="search_employees"),
 ]

--- a/users/templates/users/base.html
+++ b/users/templates/users/base.html
@@ -1,0 +1,65 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>User Management</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7BneFUf3DiXM9ImtvCM0EMN0pwW7Uw+MGAE" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-qQ1IHsd1uQKeV/rpMP7SBi46mTc6yov+pS8G1pnClXrwB3ER4W91bxTF74QTK59n" crossorigin="anonymous"></script>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{% url 'compare' %}">User Management</a>
+    <form class="d-flex me-2 position-relative">
+      <input class="form-control" type="search" placeholder="Search" aria-label="Search" id="employeeSearch" autocomplete="off">
+      <div id="searchResults" class="list-group position-absolute" style="z-index:1000;"></div>
+    </form>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item"><a class="nav-link" href="{% url 'compare' %}">Comparison</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'employees' %}">Employees</a></li>
+        <li class="nav-item"><a class="nav-link" href="{% url 'crowd_users' %}">Crowd Users</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container mt-4">
+{% block content %}{% endblock %}
+</div>
+<script>
+const searchInput = document.getElementById('employeeSearch');
+const resultsBox = document.getElementById('searchResults');
+if (searchInput) {
+  searchInput.addEventListener('input', function() {
+    const query = this.value.trim();
+    if (!query) {
+      resultsBox.innerHTML = '';
+      resultsBox.style.display = 'none';
+      return;
+    }
+    fetch(`/search/?q=` + encodeURIComponent(query))
+      .then(r => r.json())
+      .then(data => {
+        resultsBox.innerHTML = '';
+        if (!data.results || data.results.length === 0) {
+          resultsBox.style.display = 'none';
+          return;
+        }
+        data.results.forEach(emp => {
+          const a = document.createElement('a');
+          a.className = 'list-group-item list-group-item-action';
+          a.href = `/employee/${emp.employee_id}/`;
+          a.textContent = `${emp.full_name} (${emp.department})`;
+          resultsBox.appendChild(a);
+        });
+        resultsBox.style.display = 'block';
+      });
+  });
+}
+</script>
+</body>
+</html>

--- a/users/templates/users/comparison.html
+++ b/users/templates/users/comparison.html
@@ -1,14 +1,8 @@
-{% load static %}
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
-  integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7BneFUf3DiXM9ImtvCM0EMN0pwW7Uw+MGAE"
-  crossorigin="anonymous"
->
+{% extends "users/base.html" %}
+{% block content %}
 {% if error %}
 <div class="alert alert-danger" role="alert">Error fetching Crowd users: {{ error }}</div>
 {% endif %}
-<div class="container mt-4">
 <table class="table table-bordered table-striped table-hover">
     <tr>
         <th>Username</th>
@@ -29,4 +23,4 @@
     </tr>
     {% endfor %}
 </table>
-</div>
+{% endblock %}

--- a/users/templates/users/crowd_users.html
+++ b/users/templates/users/crowd_users.html
@@ -1,14 +1,8 @@
-{% load static %}
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
-  integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7BneFUf3DiXM9ImtvCM0EMN0pwW7Uw+MGAE"
-  crossorigin="anonymous"
->
+{% extends "users/base.html" %}
+{% block content %}
 {% if error %}
 <div class="alert alert-danger" role="alert">Error fetching Crowd users: {{ error }}</div>
 {% endif %}
-<div class="container mt-4">
 <table class="table table-bordered table-striped table-hover">
     <tr>
         <th>Username</th>
@@ -21,4 +15,4 @@
     </tr>
     {% endfor %}
 </table>
-</div>
+{% endblock %}

--- a/users/templates/users/employee_detail.html
+++ b/users/templates/users/employee_detail.html
@@ -1,0 +1,10 @@
+{% extends "users/base.html" %}
+{% block content %}
+<h2>{{ employee.full_name }}</h2>
+<ul class="list-group">
+    <li class="list-group-item"><strong>Username:</strong> {{ employee.username }}</li>
+    <li class="list-group-item"><strong>Employee ID:</strong> {{ employee.employee_id }}</li>
+    <li class="list-group-item"><strong>Department:</strong> {{ employee.department }}</li>
+    <li class="list-group-item"><strong>Employed:</strong> {{ employee.is_employed }}</li>
+</ul>
+{% endblock %}

--- a/users/templates/users/external_employees.html
+++ b/users/templates/users/external_employees.html
@@ -1,11 +1,5 @@
-{% load static %}
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
-  integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7BneFUf3DiXM9ImtvCM0EMN0pwW7Uw+MGAE"
-  crossorigin="anonymous"
->
-<div class="container mt-4">
+{% extends "users/base.html" %}
+{% block content %}
 <table class="table table-bordered table-striped table-hover">
     <tr>
         <th>Username</th>
@@ -24,4 +18,4 @@
     </tr>
     {% endfor %}
 </table>
-</div>
+{% endblock %}

--- a/users/tests.py
+++ b/users/tests.py
@@ -20,3 +20,19 @@ class CrowdUsersViewTests(TestCase):
         client = Client()
         response = client.get("/crowd_users/")
         self.assertEqual(response.status_code, 200)
+
+
+class EmployeeDetailViewTests(TestCase):
+    def test_employee_detail_view(self):
+        client = Client()
+        response = client.get("/employee/E001/")
+        self.assertEqual(response.status_code, 200)
+
+
+class SearchEmployeesTests(TestCase):
+    def test_search_results(self):
+        client = Client()
+        response = client.get("/search/?q=Alice")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(any("Alice" in item["full_name"] for item in data["results"]))


### PR DESCRIPTION
## Summary
- implement base template with navbar and search box
- update pages to extend the base template
- add employee detail and search views
- expose new URLs for search and employee detail
- expand tests for new endpoints

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68511d35730c8330a94daac040010f70